### PR TITLE
Update LockTimeThemePage.xaml

### DIFF
--- a/Src/LockTime/LockTimeThemePage.xaml
+++ b/Src/LockTime/LockTimeThemePage.xaml
@@ -76,6 +76,7 @@
                             <ComboBoxItem>84</ComboBoxItem>
                             <ComboBoxItem>96</ComboBoxItem>
                             <ComboBoxItem>100</ComboBoxItem>
+                            <ComboBoxItem>150</ComboBoxItem>
                             <ComboBoxItem>200</ComboBoxItem>
                         </ComboBox>
                     </ui:SettingsCard>
@@ -120,6 +121,7 @@
                             <ComboBoxItem>84</ComboBoxItem>
                             <ComboBoxItem>96</ComboBoxItem>
                             <ComboBoxItem>100</ComboBoxItem>
+                            <ComboBoxItem>150</ComboBoxItem>
                             <ComboBoxItem>200</ComboBoxItem>
                         </ComboBox>
                     </ui:SettingsCard>


### PR DESCRIPTION
在大小中增加了150的选项。
因为不能输入大小，而教室内的一体机150左右的大小比较合适。